### PR TITLE
Fix logging pipeline example

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,7 +628,7 @@ myapp-log
 
 `/etc/s6-overlay/s6-rc.d/myapp-log/type`:
 ```
-oneshot
+longrun
 ```
 
 `/etc/s6-overlay/s6-rc.d/myapp-log/run`:


### PR DESCRIPTION
Fixes a tiny inconsistency in the logging pipeline example in the readme. The myapp-log service is being declared as oneshot in the code block describing `/etc/s6-overlay/s6-rc.d/myapp-log/type`, while a few lines down it is said to be a longrun:

> myapp is a producer for myapp-log and myapp-log is a consumer for myapp, so what myapp writes to its stdout will go to myapp-log's stdin. Both are longruns, i.e. daemons that will be supervised by s6.