### PR TITLE
Fix preinit logging to use correct default level

### DIFF
--- a/layout/rootfs-overlay/package/admin/s6-overlay-@VERSION@/libexec/preinit
+++ b/layout/rootfs-overlay/package/admin/s6-overlay-@VERSION@/libexec/preinit
@@ -23,13 +23,13 @@ fatal () {
 }
 
 warning () {
-  if test "0$S6_VERBOSITY" -gt 0 ; then
+  if test "2$S6_VERBOSITY" -gt 0 ; then
     echo "$prog: warning: $*" 1>&2
   fi
 }
 
 info () {
-  if test "0$S6_VERBOSITY" -gt 1 ; then
+  if test "2$S6_VERBOSITY" -gt 1 ; then
     echo "$prog: info: $*" 1>&2
   fi
 }


### PR DESCRIPTION
This fixes #638 and makes the `preinit` logging use the default `S6_VERBOSITY=2` as stated in the README.