### PR TITLE
RFC: Treat S6_RUNTIME_PROFILE as an overlay on /etc/s6-overlay/s6-rc.d

### DIFF
--- a/layout/rootfs-overlay/package/admin/s6-overlay-@VERSION@/etc/s6-linux-init/skel/rc.init
+++ b/layout/rootfs-overlay/package/admin/s6-overlay-@VERSION@/etc/s6-linux-init/skel/rc.init
@@ -49,11 +49,21 @@ fi
 
 if profile=`printcontenv S6_RUNTIME_PROFILE` ; then
   etc="/etc/cont-profile.d/$profile"
+  rcsrc=/run/s6/rc-source
+  s6-rmrf "$rcsrc"
+  s6-mkdir -p -m 0755 "$rcsrc"
+  for entry in `s6-ls /etc/s6-overlay/s6-rc.d 2>/dev/null` ; do
+    s6-ln -s "/etc/s6-overlay/s6-rc.d/$entry" "$rcsrc/$entry"
+  done
+  for entry in `s6-ls "$etc/s6-overlay/s6-rc.d" 2>/dev/null` ; do
+    s6-ln -nsf "$etc/s6-overlay/s6-rc.d/$entry" "$rcsrc/$entry"
+  done
 else
   etc=/etc
+  rcsrc=/etc/s6-overlay/s6-rc.d
 fi
 
-s6-rc-compile -v"$cv" /run/s6/db "$etc/s6-overlay/s6-rc.d" /package/admin/s6-overlay-@VERSION@/etc/s6-rc/sources
+s6-rc-compile -v"$cv" /run/s6/db "$rcsrc" /package/admin/s6-overlay-@VERSION@/etc/s6-rc/sources
 s6-rc-init -c /run/s6/db /run/service
 
 if timeout=`printcontenv S6_CMD_WAIT_FOR_SERVICES_MAXTIME` && eltest "$timeout" =~ '^[[:digit:]]+$' ; then : ; else


### PR DESCRIPTION
Setting S6_RUNTIME_PROFILE=foo causes rc.init to use /etc/cont-profile.d/foo/s6-overlay/s6-rc.d/ as a complete replacement for /etc/s6-overlay/s6-rc.d/. This forces users to mirror every top-level entry (every service dir, the user bundle, etc.) just to deviate in one of them.

Build a merged source tree in /run/s6/rc-source from symlinks instead: inherit each top-level entry from /etc/s6-overlay/s6-rc.d/ by default, and let the profile dir override individual entries.
